### PR TITLE
edit the migrate.go to use a gorm.db in the external files

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,8 @@ import (
   "net/http"
   "github.com/gin-gonic/gin"
   // コメントを外す
-  // "optim_22_app/model"
+  "optim_22_app/model"
+  "optim_22_app/typefile"
 )
 
 func main() {
@@ -12,7 +13,22 @@ func main() {
   // 手順としては、まずコンテナを立ち上げた後、mysqlでoptim_devデータベースを作成する。
   // その後、model.InitDB(),import(optim_22_app/model)のコメントを外し、カレントディレクトリでgo run main.goを実行する。
   // プログラムの詳細はmodel/migrate.goに記載。
-  // model.InitDB()
+  model.InitDB()
+
+  // マイグレーションは定義したstructをAutoMigrateの引数に渡すことで、
+  // それに対応するテーブルの作成を行う。
+  // テーブル作成時にオプションを付けたい場合、db.Set()を利用する。
+  model.Db.AutoMigrate(&typefile.User{},&typefile.Client{},&typefile.Engineer{},&typefile.Winner{},&typefile.Request{})
+
+  // Insert
+  // db.Create(&request)
+
+  // Select
+  // db.Find(&request, "id = ?", 10)
+
+  // Batch Insert
+  // var requests = []User{request1, request2, request3}
+  // db.Create(&users)
 
   // ルーターを作成している
   router := gin.Default()

--- a/model/migrate.go
+++ b/model/migrate.go
@@ -4,10 +4,12 @@ package model
 
 import (
 	"fmt"
-	"typefile"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 )
+
+// 外部でdb操作をするためのパッケージ変数
+var Db *gorm.DB
 
 func InitDB() {
 	var err error
@@ -22,18 +24,6 @@ func InitDB() {
 		fmt.Println("database successfully configure")
 	}
 
-	// マイグレーションは定義したstructをAutoMigrateの引数に渡すことで、
-	// それに対応するテーブルの作成を行う。
-	// テーブル作成時にオプションを付けたい場合、db.Set()を利用する。
-	db.AutoMigrate(&typefile.User{},&typefile.Client{},&typefile.Engineer{},&typefile.Winner{},&typefile.Request{})
-
-	// Insert
-	// db.Create(&request)
-
-	// Select
-    // db.Find(&request, "id = ?", 10)
-
-    // Batch Insert
-    // var requests = []User{request1, request2, request3}
-    // db.Create(&users)
+	// 接続したdbをパッケージ変数Dbに代入している。
+	Db = db
 }


### PR DESCRIPTION
mgirate.goで接続したDBを外部ファイルで利用できるようにした。
そのため、外部ファイルでCRUD機能を利用できるようにした。