### PR TITLE
edit the Dockerfile and docker-compose.yml and change the winner struct

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,6 @@ WORKDIR /go/src/optim_22_app/
 # モジュールモードのためにライブラリをインストールする
 RUN go mod download
 
-# GOPATHモードのためにライブラリをインストールする(本当はモジュールモードのみのほうがよいが、完全にモジュールモードにする方法がわからないため、両方利用することにした。)
-RUN go get -u "github.com/gin-gonic/gin"
-RUN go get -u gorm.io/gorm
-RUN go get -u gorm.io/driver/mysql
-
 # イメージを実行する時、コンテナに対して何もオプションを指定しなければ、
 # 自動的に実行するコマンドを CMD 命令で指定
 CMD ["go","run","/go/src/optim_22_app/main.go"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     env_file:
       - ./.env
     environment:
+      MYSQL_DATABASE: optim_dev
       MYSQL_ROOT_HOST: "%"
       MYSQL_ROOT_PASSWORD: rootpass
       MYSQL_PASSWORD: rootpass

--- a/model/migrate.go
+++ b/model/migrate.go
@@ -70,7 +70,7 @@ func CreateTestData() {
 	Db.Create(&requests)
 	
 	var winners = []typefile.Winner{
-		{User: typefile.User{ID: 1,Name: "user1"},RequestID: 1},
-		{User: typefile.User{ID: 2,Name: "user2"},RequestID: 2}}
+		{EngineerID: 1,RequestID: 1},
+		{EngineerID: 2,RequestID: 2}}
 	Db.Create(&winners)
 }

--- a/typefile/type.go
+++ b/typefile/type.go
@@ -18,7 +18,8 @@ type Engineer struct{
 }
 
 type Winner struct{
-	User           User           `gorm:"embedded"`
+	EngineerID     int            `gorm:"not null"`
+	Engineer       Engineer
 	RequestID      int            `gorm:"not null"`
 }
 


### PR DESCRIPTION
Dockerfileに余分な記述があったため、削除した。
また、docker-compose.ymlにデータベース名を指定した。
これによって、optim_devデータベースを自動で作成するようにした。
また、Winnerの構造体を変更前はUserを埋め込んでいたが、WinnerがUserのメソッドを利用することはないため、埋め込みは適切ではないと判断し、エンジニアidを持たせることにした。
つまり、EnginnerはWinnerという称号を持っているという捉え方である。
