### PR TITLE
Add attachment url registration feature

### DIFF
--- a/internal/app/comment/repository.go
+++ b/internal/app/comment/repository.go
@@ -35,7 +35,7 @@ func (r repository) Get(ctx context.Context, requestID int) ([]comment, error) {
   var comments []comment
   result := r.db.WithContext(ctx).
     Model(&typefile.Comment{}).
-    Select("users.name, comments.title, comments.body, profiles.icon, comments.id, comments.request_id, comments.user_id, comments.reply_id, comments.created_at").
+    Select("users.name, comments.title, comments.body, profiles.icon, comments.id, comments.request_id, comments.user_id, comments.reply_id, comments.created_at, comments.attachment").
     Joins("INNER JOIN users ON comments.user_id = users.id").
     Joins("INNER JOIN profiles ON profiles.id = users.id").
     Find(&comments, "comments.request_id = ?", requestID)
@@ -44,8 +44,8 @@ func (r repository) Get(ctx context.Context, requestID int) ([]comment, error) {
 }
 
 
-func (r repository) Create(ctx context.Context, comments *typefile.Comment) error {
-  result := r.db.WithContext(ctx).Create(comments)
+func (r repository) Create(ctx context.Context, comment *typefile.Comment) error {
+  result := r.db.WithContext(ctx).Create(comment)
   return result.Error
 }
 

--- a/internal/app/comment/service.go
+++ b/internal/app/comment/service.go
@@ -34,7 +34,8 @@ func (m comment) Validate() error {
     validation.Field(&m.Title, validation.Required, validation.Length(3, 640)),
     validation.Field(&m.Body, validation.Required, validation.Length(3, 1280)),
     //validation.Field(&m.ReplyID, validation.Required, is.Int),
-    //validation.Field(&m.Attachment, validation.Length(3, 128)),
+    //URL
+    validation.Field(&m.Attachment, validation.Length(1, 2048)),
   )
 }
 //#endregion
@@ -89,11 +90,12 @@ func (s service) Post(ctx context.Context, req comment, requestID string) error 
   }
   //クエリの値を定義
   insertValues := typefile.Comment{
-    RequestID: requestIDAsInt,
-    UserID:    req.UserID,
-    Title:     req.Title,
-    Body:      req.Body,
-    ReplyID:   req.ReplyID,
+    RequestID:  requestIDAsInt,
+    UserID:     req.UserID,
+    Title:      req.Title,
+    Body:       req.Body,
+    ReplyID:    req.ReplyID,
+    Attachment: req.Attachment,
   }
 
   if err := s.repo.Create(ctx, &insertValues); err != nil {
@@ -116,11 +118,12 @@ func (s service) Patch(ctx context.Context, req comment, requestID string) error
   }
   //クエリの値を定義
   insertValues := typefile.Comment{
-    RequestID: requestIDAsInt,
-    UserID:    req.UserID,
-    Title:     req.Title,
-    Body:      req.Body,
-    ReplyID:   req.ReplyID,
+    RequestID:  requestIDAsInt,
+    UserID:     req.UserID,
+    Title:      req.Title,
+    Body:       req.Body,
+    ReplyID:    req.ReplyID,
+    Attachment: req.Attachment,
   }
 
   if err := s.repo.Update(ctx, &insertValues); err != nil {

--- a/typefile/type.go
+++ b/typefile/type.go
@@ -68,4 +68,5 @@ type Comment struct {
   Title      string    
   Body       string    
   ReplyID    int  
+  Attachment string              `gorm:"type:varchar(2048)"`  
 }


### PR DESCRIPTION
コメント投稿機能に付随する添付ファイルのURLを登録する機能に対応
2048文字制限
[「URLの長さは2,000文字より短くした方がいい」とGoogleのMueller氏がアドバイス ｜ SEOモード](https://www.tyto-style.com/blog/archives/2725)